### PR TITLE
Don't return full network object on add_network

### DIFF
--- a/hydra_server/server/complexmodels.py
+++ b/hydra_server/server/complexmodels.py
@@ -884,10 +884,16 @@ class ResourceSummary(HydraComplexModel):
     ]
 
     def __init__(self, parent=None, include_attributes=True):
+        """
+            args:
+                parent: The ORM or JSONObject representing the Node / Link / Group / Network / Project
+                include_attributes: Include resource attributes or not. Setting to False is has significant performance benefits.
+        """
         super(ResourceSummary, self).__init__()
 
         if parent is None:
-            parent
+            return
+
         self.id   = parent.id
         self.name = parent.name
         self.description = parent.description

--- a/hydra_server/server/complexmodels.py
+++ b/hydra_server/server/complexmodels.py
@@ -883,7 +883,7 @@ class ResourceSummary(HydraComplexModel):
         ('types',       SpyneArray(TypeSummary)),
     ]
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, include_attributes=True):
         super(ResourceSummary, self).__init__()
 
         if parent is None:
@@ -898,8 +898,9 @@ class ResourceSummary(HydraComplexModel):
             self.ref_key = 'LINK'
         elif hasattr(parent, 'group_id'):
             self.ref_key = 'GROUP'
+        if include_attributes:
+            self.attributes = [ResourceAttr(ra) for ra in parent.attributes]
 
-        self.attributes = [ResourceAttr(ra) for ra in parent.attributes]
         self.types = [TypeSummary(t) for t in parent.types]
 
 class Node(Resource):

--- a/hydra_server/server/network.py
+++ b/hydra_server/server/network.py
@@ -38,7 +38,7 @@ class NetworkService(HydraService):
         The network SOAP service.
     """
 
-    @rpc(Network, _returns=Network)
+    @rpc(Network, _returns=ResourceSummary)
     def add_network(ctx, net):
         """
         Takes an entire network complex model and saves it to the DB.  This
@@ -62,7 +62,9 @@ class NetworkService(HydraService):
 
         """
         net = hb.network.add_network(net, **ctx.in_header.__dict__)
-        ret_net = Network(net, include_attributes=True)
+        log.info("Creating response Network")
+        ret_net = ResourceSummary(net, include_attributes=False)
+        log.info("Response Network Created")
 
         return ret_net
 


### PR DESCRIPTION
Creating the Network object is very time consuming, and unnecessary when the network has just been created.
The only really important thing to return is the newly created ID, so this is retuned in the lighter-weight ResourceSummary object.