### PR TITLE
Update return type as in hydra-base#268

### DIFF
--- a/hydra_server/server/attributes.py
+++ b/hydra_server/server/attributes.py
@@ -295,7 +295,7 @@ class AttributeService(HydraService):
 
         return ResourceAttr(new_ra)
 
-    @rpc(SpyneArray(AnyDict), _returns=SpyneArray(Integer))
+    @rpc(SpyneArray(AnyDict), _returns=AnyDict)
     def add_resource_attributes(ctx,resource_attributes):
         """
         Add a resource attribute to a node.


### PR DESCRIPTION
Closes #39 , see also [hydra-base#268](https://github.com/hydraplatform/hydra-base/issues/268).

To match `lib.attributes.add_resource_attributes()`, Spyne return type becomes `AnyDict`.